### PR TITLE
Fix: Itinerary controller route conflict

### DIFF
--- a/src/itinerary/itinerary.controller.ts
+++ b/src/itinerary/itinerary.controller.ts
@@ -41,6 +41,42 @@ export class ItineraryController {
     )
   }
 
+  @Get('me')
+  async findMyItineraries(
+    @GetUser() user: User,
+    @Query() paginationDto: PaginationDto
+  ) {
+    const itinerary = await this.itineraryService.findMyItineraries(
+      user.id,
+      parseInt(paginationDto.page)
+    )
+    return this.responseUtil.response(
+      {
+        statusCode: HttpStatus.OK,
+        message: 'Itineraries fetched successfully.',
+      },
+      {
+        itinerary,
+      }
+    )
+  }
+
+  @Get('me/completed')
+  async findMyCompletedItineraries(@GetUser() user: User) {
+    const itinerary = await this.itineraryService.findMyCompletedItineraries(
+      user.id
+    )
+    return this.responseUtil.response(
+      {
+        statusCode: HttpStatus.OK,
+        message: 'Itineraries fetched successfully.',
+      },
+      {
+        itinerary,
+      }
+    )
+  }
+
   @Get(':id')
   async findOne(@Param('id') id: string) {
     const itinerary = await this.itineraryService.findOne(id)
@@ -93,42 +129,6 @@ export class ItineraryController {
         message: 'Itinerary updated successfully',
       },
       itinerary
-    )
-  }
-
-  @Get('me')
-  async findMyItineraries(
-    @GetUser() user: User,
-    @Query() paginationDto: PaginationDto
-  ) {
-    const itinerary = await this.itineraryService.findMyItineraries(
-      user.id,
-      parseInt(paginationDto.page)
-    )
-    return this.responseUtil.response(
-      {
-        statusCode: HttpStatus.OK,
-        message: 'Itineraries fetched successfully.',
-      },
-      {
-        itinerary,
-      }
-    )
-  }
-
-  @Get('me/completed')
-  async findMyCompletedItineraries(@GetUser() user: User) {
-    const itinerary = await this.itineraryService.findMyCompletedItineraries(
-      user.id
-    )
-    return this.responseUtil.response(
-      {
-        statusCode: HttpStatus.OK,
-        message: 'Itineraries fetched successfully.',
-      },
-      {
-        itinerary,
-      }
     )
   }
 


### PR DESCRIPTION
Previously, the `/me` route was being interpreted as `/:id` due to route order.
Moved `/me` and `/me/completed` above `/:id` to prevent conflicts.
Now, `/me` correctly resolves to fetching the authenticated user's itineraries.

### Fixes
- Fixed an issue where `/me` was being treated as `/:id` due to route ordering.

### Changes
- Moved `/me` and `/me/completed` routes above `/:id` to ensure proper request handling.
- This ensures that `/me` correctly fetches the user's itineraries instead of being misinterpreted.