### PR TITLE
chore: create notion cicd optional

### DIFF
--- a/.github/workflows/notion.yml
+++ b/.github/workflows/notion.yml
@@ -13,14 +13,30 @@ jobs:
 
       - name: Extract PBI Number from PR Title
         run: |
-          PBI_NUMBER=$(echo "${{ github.event.pull_request.title }}" | grep -ioE '[pP][bB][iI] [0-9]+' | awk '{print $2}')
+          PBI_NUMBER=$(echo "${{ github.event.pull_request.title }}" | grep -oE 'PBI [0-9]+' | awk '{print $2}')
           if [ -z "$PBI_NUMBER" ]; then
-            echo "PBI number not found in PR title"
-            exit 1
+            echo "PBI number not found in PR title, skipping Notion update"
+            echo "HAS_PBI=false" >> $GITHUB_ENV
+          else
+            echo "PBI_NUMBER=$PBI_NUMBER" >> $GITHUB_ENV
+            echo "HAS_PBI=true" >> $GITHUB_ENV
           fi
-          echo "PBI_NUMBER=$PBI_NUMBER" >> $GITHUB_ENV
+
+      - name: Post warning comment for missing PBI
+        if: env.HAS_PBI == 'false'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ **Warning:** PBI number not found in PR title. Skipping status update.'
+            })
 
       - name: Determine Task Status
+        if: env.HAS_PBI == 'true'
         run: |
           if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
             echo "TASK_STATUS=Done" >> $GITHUB_ENV
@@ -29,6 +45,7 @@ jobs:
           fi
 
       - name: Get Notion Page ID by PBI Number
+        if: env.HAS_PBI == 'true'
         run: |
           RESPONSE=$(curl -X POST "https://api.notion.com/v1/databases/${{ secrets.NOTION_DATABASE_ID }}/query" \
           -H "Authorization: Bearer ${{ secrets.NOTION_API_KEY }}" \
@@ -47,14 +64,16 @@ jobs:
 
           if [ "$PAGE_ID" == "null" ]; then
             echo "Task dengan PBI $PBI_NUMBER tidak ditemukan di Notion"
-            exit 1
+            echo "TASK_FOUND=false" >> $GITHUB_ENV
+          else
+            echo "PAGE_ID=$PAGE_ID" >> $GITHUB_ENV
+            echo "TASK_FOUND=true" >> $GITHUB_ENV
           fi
 
-          echo "PAGE_ID=$PAGE_ID" >> $GITHUB_ENV
-
       - name: Update Task Status in Notion
+        if: env.HAS_PBI == 'true' && env.TASK_FOUND == 'true'
         run: |
-          curl -X PATCH "https://api.notion.com/v1/pages/$PAGE_ID" \
+          curl -X PATCH "https://api.notion.com/v1/pages/${{ env.PAGE_ID }}" \
           -H "Authorization: Bearer ${{ secrets.NOTION_API_KEY }}" \
           -H "Notion-Version: 2022-06-28" \
           -H "Content-Type: application/json" \
@@ -67,3 +86,16 @@ jobs:
               }
             }
           }'
+
+      - name: Post warning comment on PR
+        if: env.HAS_PBI == 'true' && env.TASK_FOUND == 'false'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ **Warning:** Task with PBI number ${{ env.PBI_NUMBER }} not found in Notion. Skipping status update.'
+            })


### PR DESCRIPTION
Membuat integrasi Notion dalam CI/CD workflow menjadi opsional, sehingga kegagalan pada proses update Notion tidak akan menyebabkan status Pull Request menjadi merah (failed). Dengan perubahan ini:

- Proses deployment dan review dapat terus berjalan meskipun integrasi dengan Notion mengalami masalah
- Mengurangi blocker pada workflow development tim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved workflow feedback by posting warning notifications on pull requests when expected task identifiers are missing.
	- Enhanced error handling ensures that task updates proceed smoothly without premature interruptions, providing clearer communication during the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->