### PR TITLE
fix/Pagination error when marking the last itinerary on the last page as completed

### DIFF
--- a/src/itinerary/itinerary.controller.spec.ts
+++ b/src/itinerary/itinerary.controller.spec.ts
@@ -820,7 +820,9 @@ describe('ItineraryController', () => {
       mockResponseUtil.response.mockResolvedValue(mockResponse)
 
       // Call controller method
-      const result = await controller.findMyCompletedItineraries(mockUser)
+      const result = await controller.findMyCompletedItineraries(mockUser, {
+        page: '1',
+      })
 
       // Expected response
       expect(result).toEqual({
@@ -832,7 +834,7 @@ describe('ItineraryController', () => {
       // Ensure service method called correctly
       expect(
         mockItineraryService.findMyCompletedItineraries
-      ).toHaveBeenCalledWith('user-1')
+      ).toHaveBeenCalledWith('user-1', 1)
 
       // Ensure responseUtil.response called correctly
       expect(responseUtil.response).toHaveBeenCalledWith(
@@ -857,7 +859,9 @@ describe('ItineraryController', () => {
       mockItineraryService.findMyCompletedItineraries.mockResolvedValue([])
       mockResponseUtil.response.mockResolvedValue(mockResponse)
 
-      const result = await controller.findMyCompletedItineraries(mockUser)
+      const result = await controller.findMyCompletedItineraries(mockUser, {
+        page: '1',
+      })
 
       expect(result).toEqual({
         statusCode: HttpStatus.OK,
@@ -867,7 +871,7 @@ describe('ItineraryController', () => {
 
       expect(
         mockItineraryService.findMyCompletedItineraries
-      ).toHaveBeenCalledWith('user-2')
+      ).toHaveBeenCalledWith('user-2', 1)
     })
   })
 
@@ -1012,7 +1016,9 @@ describe('ItineraryController', () => {
       mockResponseUtil.response.mockResolvedValue(mockResponse)
 
       // Call controller method
-      const result = await controller.findMyCompletedItineraries(mockUser)
+      const result = await controller.findMyCompletedItineraries(mockUser, {
+        page: '1',
+      })
 
       // Expected response
       expect(result).toEqual({
@@ -1024,7 +1030,7 @@ describe('ItineraryController', () => {
       // Ensure service method called correctly
       expect(
         mockItineraryService.findMyCompletedItineraries
-      ).toHaveBeenCalledWith('user-1')
+      ).toHaveBeenCalledWith('user-1', 1)
 
       // Ensure responseUtil.response called correctly
       expect(responseUtil.response).toHaveBeenCalledWith(
@@ -1049,7 +1055,9 @@ describe('ItineraryController', () => {
       mockItineraryService.findMyCompletedItineraries.mockResolvedValue([])
       mockResponseUtil.response.mockResolvedValue(mockResponse)
 
-      const result = await controller.findMyCompletedItineraries(mockUser)
+      const result = await controller.findMyCompletedItineraries(mockUser, {
+        page: '1',
+      })
 
       expect(result).toEqual({
         statusCode: HttpStatus.OK,
@@ -1059,7 +1067,7 @@ describe('ItineraryController', () => {
 
       expect(
         mockItineraryService.findMyCompletedItineraries
-      ).toHaveBeenCalledWith('user-2')
+      ).toHaveBeenCalledWith('user-2', 1)
     })
   })
 

--- a/src/itinerary/itinerary.controller.ts
+++ b/src/itinerary/itinerary.controller.ts
@@ -110,9 +110,13 @@ export class ItineraryController {
   }
 
   @Get('me/completed')
-  async findMyCompletedItineraries(@GetUser() user: User) {
+  async findMyCompletedItineraries(
+    @GetUser() user: User,
+    @Query() paginationDto: PaginationDto
+  ) {
     const itinerary = await this.itineraryService.findMyCompletedItineraries(
-      user.id
+      user.id,
+      parseInt(paginationDto.page)
     )
     return this.responseUtil.response(
       {

--- a/src/itinerary/itinerary.service.spec.ts
+++ b/src/itinerary/itinerary.service.spec.ts
@@ -1924,6 +1924,8 @@ describe('ItineraryService', () => {
             { blocks: [{ blockType: 'LOCATION' }, { blockType: 'LOCATION' }] },
             { blocks: [{ blockType: 'LOCATION' }] },
           ],
+          access: [],
+          pendingInvites: [],
         },
         {
           id: 'itinerary-2',
@@ -1932,6 +1934,8 @@ describe('ItineraryService', () => {
           isCompleted: true,
           startDate: new Date(),
           sections: [{ blocks: [{ blockType: 'LOCATION' }] }],
+          access: [],
+          pendingInvites: [],
         },
       ]
 
@@ -1939,10 +1943,10 @@ describe('ItineraryService', () => {
       mockPrismaService.itinerary.findMany.mockResolvedValue(mockItineraries)
 
       // Panggil fungsi yang akan diuji
-      const result = await service.findMyCompletedItineraries('user-1')
+      const result = await service.findMyCompletedItineraries('user-1', 1)
 
       // Cek hasilnya sesuai dengan ekspektasi
-      expect(result).toEqual([
+      expect(result.data).toEqual([
         {
           id: 'itinerary-1',
           userId: 'user-1',
@@ -1951,6 +1955,9 @@ describe('ItineraryService', () => {
           startDate: expect.any(Date),
           sections: expect.any(Array),
           locationCount: 3, // Total lokasi dalam itinerary ini
+          access: [],
+          pendingInvites: [],
+          invitedUsers: [],
         },
         {
           id: 'itinerary-2',
@@ -1960,28 +1967,47 @@ describe('ItineraryService', () => {
           startDate: expect.any(Date),
           sections: expect.any(Array),
           locationCount: 1, // Total lokasi dalam itinerary ini
+          access: [],
+          pendingInvites: [],
+          invitedUsers: [],
         },
       ])
 
       // Pastikan findMany terpanggil dengan benar
       expect(mockPrismaService.itinerary.findMany).toHaveBeenCalledWith({
         where: { userId: 'user-1', isCompleted: true },
+        take: PAGINATION_LIMIT,
+        skip: (1 - 1) * PAGINATION_LIMIT,
         orderBy: { startDate: 'asc' },
         include: {
           sections: {
             include: {
               blocks: {
-                include: {
-                  routeFromPrevious: true,
-                  routeToNext: true,
-                },
                 where: { blockType: 'LOCATION' },
+                include: {
+                  routeToNext: true,
+                  routeFromPrevious: true,
+                },
               },
             },
           },
           tags: {
             include: {
               tag: true,
+            },
+          },
+          pendingInvites: true,
+          access: {
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  firstName: true,
+                  lastName: true,
+                  photoProfile: true,
+                  email: true,
+                },
+              },
             },
           },
         },
@@ -2034,33 +2060,21 @@ describe('ItineraryService', () => {
     })
 
     it('should return an empty array when there are no completed itineraries', async () => {
-      // Mock return value kosong
       mockPrismaService.itinerary.findMany.mockResolvedValue([])
 
-      const result = await service.findMyCompletedItineraries('user-2')
+      const result = await service.findMyCompletedItineraries('user-2', 1)
 
-      expect(result).toEqual([])
-      expect(mockPrismaService.itinerary.findMany).toHaveBeenCalledWith({
-        where: { userId: 'user-2', isCompleted: true },
-        orderBy: { startDate: 'asc' },
-        include: {
-          sections: {
-            include: {
-              blocks: {
-                include: {
-                  routeFromPrevious: true,
-                  routeToNext: true,
-                },
-                where: { blockType: 'LOCATION' },
-              },
-            },
-          },
-          tags: {
-            include: {
-              tag: true,
-            },
-          },
-        },
+      expect(result.data).toEqual([])
+      expect(mockPrismaService.itinerary.findMany).toHaveBeenCalled()
+
+      const findManyCall = mockPrismaService.itinerary.findMany.mock.calls[0][0]
+      expect(findManyCall.where).toEqual({
+        userId: 'user-2',
+        isCompleted: true,
+      })
+      expect(findManyCall.orderBy).toEqual({ startDate: 'asc' })
+      expect(findManyCall.include.sections.include.blocks.where).toEqual({
+        blockType: 'LOCATION',
       })
     })
   })


### PR DESCRIPTION
Fixes a pagination edge case where deleting (marking as completed) the **only itinerary on the last page** causes the list to become empty and throws an error or displays a blank state.

This change ensures that when the current page becomes empty after an item is removed, the system will automatically go back to the **previous page** (if it exists) and fetch data again.

## Changes
- change `findMyCompletedItineraries` to support pagination
- update test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced pagination for viewing completed itineraries. Users can now navigate itineraries by pages, and responses include metadata such as total count, current page, and total pages.
  
- **Bug Fixes**
  - Enhanced input validation to ensure only valid page numbers are accepted, improving overall error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->