### PR TITLE
fix/user can delete other itineraries

### DIFF
--- a/src/itinerary/itinerary.controller.spec.ts
+++ b/src/itinerary/itinerary.controller.spec.ts
@@ -1238,12 +1238,13 @@ describe('ItineraryController', () => {
 
       jest.spyOn(responseUtil, 'response').mockReturnValue(responseMock)
 
-      const result = await controller.removeItinerary(itineraryId)
+      const result = await controller.removeItinerary(itineraryId, mockUser)
 
       expect(mockItineraryService.removeItinerary).toHaveBeenCalledWith(
-        itineraryId
+        itineraryId,
+        mockUser.id
       )
-      expect(responseUtil.response).toHaveBeenCalledWith(responseMock, null)
+      expect(responseUtil.response).toHaveBeenCalledWith(responseMock)
       expect(result).toEqual(responseMock)
     })
     it('should throw an error if itinerary is not found', async () => {
@@ -1252,12 +1253,13 @@ describe('ItineraryController', () => {
 
       mockItineraryService.removeItinerary.mockRejectedValue(error)
 
-      await expect(controller.removeItinerary(itineraryId)).rejects.toThrow(
-        'Not Found'
-      )
+      await expect(
+        controller.removeItinerary(itineraryId, mockUser)
+      ).rejects.toThrow('Not Found')
 
       expect(mockItineraryService.removeItinerary).toHaveBeenCalledWith(
-        itineraryId
+        itineraryId,
+        mockUser.id
       )
     })
   })

--- a/src/itinerary/itinerary.controller.spec.ts
+++ b/src/itinerary/itinerary.controller.spec.ts
@@ -1242,7 +1242,7 @@ describe('ItineraryController', () => {
 
       expect(mockItineraryService.removeItinerary).toHaveBeenCalledWith(
         itineraryId,
-        mockUser.id
+        mockUser
       )
       expect(responseUtil.response).toHaveBeenCalledWith(responseMock)
       expect(result).toEqual(responseMock)
@@ -1259,7 +1259,7 @@ describe('ItineraryController', () => {
 
       expect(mockItineraryService.removeItinerary).toHaveBeenCalledWith(
         itineraryId,
-        mockUser.id
+        mockUser
       )
     })
   })

--- a/src/itinerary/itinerary.controller.ts
+++ b/src/itinerary/itinerary.controller.ts
@@ -199,15 +199,12 @@ export class ItineraryController {
   }
 
   @Delete(':id')
-  async removeItinerary(@Param('id') id: string) {
-    await this.itineraryService.removeItinerary(id)
-    return this.responseUtil.response(
-      {
-        statusCode: HttpStatus.OK,
-        message: 'Itinerary deleted successfully.',
-      },
-      null
-    )
+  async removeItinerary(@Param('id') id: string, @GetUser() user: User) {
+    await this.itineraryService.removeItinerary(id, user)
+    return this.responseUtil.response({
+      statusCode: HttpStatus.OK,
+      message: 'Itinerary deleted successfully.',
+    })
   }
 
   @Post(':id/invite')

--- a/src/itinerary/itinerary.service.spec.ts
+++ b/src/itinerary/itinerary.service.spec.ts
@@ -2165,13 +2165,11 @@ describe('ItineraryService', () => {
         id: 'different-user-id',
       }
 
-      // Mock the itinerary with a different owner
-      mockPrismaService.itinerary.findUnique.mockResolvedValueOnce({
+      mockPrismaService.itinerary.findUnique.mockResolvedValue({
         id: itineraryId,
-        userId: 'original-owner-id', // Different from the requesting user
+        userId: 'original-owner-id',
       })
 
-      // Mock _checkUpdateItineraryPermission to throw ForbiddenException
       jest
         .spyOn(service, '_checkUpdateItineraryPermission')
         .mockImplementation(() => {
@@ -2180,7 +2178,6 @@ describe('ItineraryService', () => {
           )
         })
 
-      // Act & Assert
       await expect(
         service.removeItinerary(itineraryId, anotherUser)
       ).rejects.toThrow(ForbiddenException)

--- a/src/itinerary/itinerary.service.spec.ts
+++ b/src/itinerary/itinerary.service.spec.ts
@@ -2124,10 +2124,12 @@ describe('ItineraryService', () => {
 
       mockPrismaService.itinerary.findUnique.mockResolvedValue({
         id: itineraryId,
+        userId: mockUser.id,
       })
       mockPrismaService.itinerary.delete.mockResolvedValue({ id: itineraryId })
 
-      await expect(service.removeItinerary(itineraryId)).resolves.toEqual({
+      const result = await service.removeItinerary(itineraryId, mockUser)
+      expect(result).toEqual({
         id: itineraryId,
       })
 
@@ -2135,7 +2137,7 @@ describe('ItineraryService', () => {
         where: { id: itineraryId },
       })
 
-      expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
+      expect(mockPrismaService.itinerary.delete).toHaveBeenCalledWith({
         where: { id: itineraryId },
       })
     })
@@ -2145,14 +2147,48 @@ describe('ItineraryService', () => {
 
       mockPrismaService.itinerary.findUnique.mockResolvedValue(null)
 
-      await expect(service.removeItinerary(itineraryId)).rejects.toThrow(
-        NotFoundException
-      )
+      await expect(
+        service.removeItinerary(itineraryId, mockUser)
+      ).rejects.toThrow(NotFoundException)
 
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: itineraryId },
       })
 
+      expect(mockPrismaService.itinerary.delete).not.toHaveBeenCalled()
+    })
+
+    it('should throw ForbiddenException when user is not the owner of the itinerary', async () => {
+      const itineraryId = 'ITN456'
+      const anotherUser = {
+        ...mockUser,
+        id: 'different-user-id',
+      }
+
+      // Mock the itinerary with a different owner
+      mockPrismaService.itinerary.findUnique.mockResolvedValueOnce({
+        id: itineraryId,
+        userId: 'original-owner-id', // Different from the requesting user
+      })
+
+      // Mock _checkUpdateItineraryPermission to throw ForbiddenException
+      jest
+        .spyOn(service, '_checkUpdateItineraryPermission')
+        .mockImplementation(() => {
+          throw new ForbiddenException(
+            'You do not have permission to update this itinerary'
+          )
+        })
+
+      // Act & Assert
+      await expect(
+        service.removeItinerary(itineraryId, anotherUser)
+      ).rejects.toThrow(ForbiddenException)
+
+      expect(service._checkUpdateItineraryPermission).toHaveBeenCalledWith(
+        itineraryId,
+        anotherUser
+      )
       expect(mockPrismaService.itinerary.delete).not.toHaveBeenCalled()
     })
   })

--- a/src/itinerary/itinerary.service.ts
+++ b/src/itinerary/itinerary.service.ts
@@ -760,13 +760,15 @@ export class ItineraryService {
     return itinerary
   }
 
-  async removeItinerary(id: string) {
+  async removeItinerary(id: string, user: User) {
+    await this._checkUpdateItineraryPermission(id, user)
     const itinerary = await this.prisma.itinerary.findUnique({
       where: { id },
     })
     if (!itinerary) {
       throw new NotFoundException('Itinerary not found')
     }
+
     return this.prisma.itinerary.delete({
       where: { id },
     })
@@ -793,7 +795,7 @@ export class ItineraryService {
     if (!itinerary) {
       throw new NotFoundException(`Itinerary with ID ${itineraryId} not found`)
     }
-
+    console.log(itinerary)
     if (itinerary.userId !== userId) {
       throw new ForbiddenException(
         'Not authorized to invite users to this itinerary'


### PR DESCRIPTION
Fixes a security issue where any authenticated user could delete an itinerary **not owned by them**, by calling the `DELETE /itineraries/:id` endpoint directly.

This update ensures that only the **owner of the itinerary** has permission to delete it.

## Changes

- Added ownership check in `removeItinerary()` service method
  - Verifies that the requesting user is the creator/owner of the itinerary before allowing deletion
- Returns `403 Forbidden` if the user does not have permission
- Refactored method signature to accept `userId` and pass it from controller
- Updated error message for unauthorized deletion attempt

## Notes

- This change is critical to ensure data access control and user authorization
- Make sure to update controller to pass `userId` from the authenticated session/context

Fixes #77 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Itinerary deletion now requires user verification, ensuring that only authorized users can remove itineraries.
  - Users will receive clearer error notifications when attempts to delete non-existent or unauthorized itineraries occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->