### PR TITLE
Fix: Exclude contingency plan from location count

### DIFF
--- a/src/itinerary/itinerary.service.ts
+++ b/src/itinerary/itinerary.service.ts
@@ -450,6 +450,9 @@ export class ItineraryService {
         orderBy: { startDate: 'asc' },
         include: {
           sections: {
+            where: {
+              contingencyPlanId: null,
+            },
             include: {
               blocks: {
                 where: { blockType: 'LOCATION' },


### PR DESCRIPTION
CHANGES:
- Location:
![image](https://github.com/user-attachments/assets/451345c3-6905-4fda-b67b-ad86346ff3c6)

- Before (include contingency plans):
![image](https://github.com/user-attachments/assets/5c75c003-0529-4dab-bb69-dcb08f313794)

- After:
![image](https://github.com/user-attachments/assets/de24dd9b-aca6-4bf7-92f1-74623ee29662)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Itinerary displays have been refined to show only the most relevant sections. Users will now see itinerary details that exclude sections with an associated contingency plan, resulting in a more streamlined and consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->