### PR TITLE
Fix/Itinerary Permission Refactoring

### DIFF
--- a/src/itinerary/itinerary.controller.ts
+++ b/src/itinerary/itinerary.controller.ts
@@ -140,7 +140,6 @@ export class ItineraryController {
       }
     }
 
-    console.log(itinerary)
     return this.responseUtil.response(
       {
         statusCode: HttpStatus.OK,

--- a/src/itinerary/itinerary.service.spec.ts
+++ b/src/itinerary/itinerary.service.spec.ts
@@ -1688,6 +1688,11 @@ describe('ItineraryService', () => {
 
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: 'non-existent-id' },
+        include: {
+          access: {
+            where: { userId: mockUser.id },
+          },
+        },
       })
     })
 
@@ -1707,6 +1712,11 @@ describe('ItineraryService', () => {
 
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: 'itinerary-123' },
+        include: {
+          access: {
+            where: { userId: mockUser.id },
+          },
+        },
       })
     })
 
@@ -1729,6 +1739,11 @@ describe('ItineraryService', () => {
       expect(result).toEqual(mockItinerary)
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: 'itinerary-123' },
+        include: {
+          access: {
+            where: { userId: mockUser.id },
+          },
+        },
       })
     })
   })
@@ -2450,6 +2465,11 @@ describe('ItineraryService', () => {
 
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: itineraryId },
+        include: {
+          access: {
+            where: { userId: mockUser.id },
+          },
+        },
       })
 
       expect(mockPrismaService.itinerary.delete).toHaveBeenCalledWith({
@@ -2468,6 +2488,11 @@ describe('ItineraryService', () => {
 
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: itineraryId },
+        include: {
+          access: {
+            where: { userId: mockUser.id },
+          },
+        },
       })
 
       expect(mockPrismaService.itinerary.delete).not.toHaveBeenCalled()
@@ -3280,6 +3305,11 @@ describe('ItineraryService', () => {
       // Assert
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: itineraryId },
+        include: {
+          access: {
+            where: { userId: mockUser.id },
+          },
+        },
       })
 
       expect(mockPrismaService.contingencyPlan.findUnique).toHaveBeenCalledWith(
@@ -3333,6 +3363,11 @@ describe('ItineraryService', () => {
 
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: itineraryId },
+        include: {
+          access: {
+            where: { userId: mockUser.id },
+          },
+        },
       })
 
       expect(mockPrismaService.contingencyPlan.findUnique).toHaveBeenCalledWith(
@@ -3379,6 +3414,11 @@ describe('ItineraryService', () => {
 
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: itineraryId },
+        include: {
+          access: {
+            where: { userId: mockUser.id },
+          },
+        },
       })
 
       expect(mockPrismaService.contingencyPlan.findUnique).toHaveBeenCalledWith(
@@ -3472,6 +3512,11 @@ describe('ItineraryService', () => {
       // Assert
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: itineraryId },
+        include: {
+          access: {
+            where: { userId: mockUser.id },
+          },
+        },
       })
 
       expect(mockPrismaService.contingencyPlan.findUnique).toHaveBeenCalledWith(
@@ -3673,6 +3718,11 @@ describe('ItineraryService', () => {
       // Assert
       expect(mockPrismaService.itinerary.findUnique).toHaveBeenCalledWith({
         where: { id: itineraryId },
+        include: {
+          access: {
+            where: { userId: mockUser.id },
+          },
+        },
       })
 
       expect(mockPrismaService.contingencyPlan.findUnique).toHaveBeenCalledWith(

--- a/src/itinerary/itinerary.service.ts
+++ b/src/itinerary/itinerary.service.ts
@@ -294,6 +294,12 @@ export class ItineraryService {
     })
   }
 
+  /**
+   * Checks whether itinerary with given id exists
+   * @param id Id for Itinerary
+   * @param user User for permission check
+   * @returns A simple Itinerary object
+   */
   async _checkItineraryExists(id: string, user: User) {
     const itinerary = await this.prisma.itinerary.findUnique({
       where: { id },
@@ -307,31 +313,41 @@ export class ItineraryService {
     if (!itinerary) {
       throw new NotFoundException(`Itinerary with ID ${id} not found`)
     }
-
-    if (itinerary.userId !== user.id && itinerary.access.length === 0) {
-      throw new ForbiddenException(
-        'You do not have permission to update or view this itinerary'
-      )
-    }
-
     return itinerary
   }
 
-  async _checkUpdateItineraryPermission(id: string, user: User) {
-    const itinerary = await this.prisma.itinerary.findUnique({
-      where: { id },
-    })
+  /**
+   * Checks whether user has READ access to a given itinerary or not
+   * @param id Id for Itinerary
+   * @param user User for permission check
+   * @returns A simple Itinerary object
+   */
+  async _checkReadItineraryPermission(id: string, user: User) {
+    const itinerary = await this._checkItineraryExists(id, user)
 
-    if (!itinerary) {
-      throw new NotFoundException(`Itinerary with ID ${id} not found`)
+    if (itinerary.userId !== user.id) {
+      if (!itinerary.isPublished && itinerary.access.length === 0)
+        throw new ForbiddenException(
+          'You do not have permission to view this itinerary'
+        )
     }
+    return itinerary
+  }
+
+  /**
+   * Checks whether user has UPDATE access to a given itinerary or not
+   * @param id Id for Itinerary
+   * @param user User for permission check
+   * @returns A simple Itinerary object
+   */
+  async _checkUpdateItineraryPermission(id: string, user: User) {
+    const itinerary = await this._checkItineraryExists(id, user)
 
     if (itinerary.userId !== user.id) {
       throw new ForbiddenException(
         'You do not have permission to update this itinerary'
       )
     }
-
     return itinerary
   }
 

--- a/src/itinerary/itinerary.service.ts
+++ b/src/itinerary/itinerary.service.ts
@@ -163,7 +163,6 @@ export class ItineraryService {
   }
 
   async updateItinerary(id: string, data: UpdateItineraryDto, user: User) {
-    await this._checkItineraryExists(id, user)
     await this._checkUpdateItineraryPermission(id, user)
     this._validateItineraryDates(data)
     this._validateItinerarySections(data)
@@ -778,7 +777,7 @@ export class ItineraryService {
   }
 
   async findOne(id: string, user: User) {
-    await this._checkItineraryExists(id, user)
+    await this._checkReadItineraryPermission(id, user)
     const itinerary = await this.prisma.itinerary.findUnique({
       where: { id: id },
       include: {
@@ -968,7 +967,7 @@ export class ItineraryService {
   }
 
   async findContingencyPlans(itineraryId: string, user: User) {
-    const itinerary = await this._checkUpdateItineraryPermission(
+    const itinerary = await this._checkReadItineraryPermission(
       itineraryId,
       user
     )
@@ -986,7 +985,7 @@ export class ItineraryService {
     contingencyPlanId: string,
     user: User
   ) {
-    const itinerary = await this._checkUpdateItineraryPermission(
+    const itinerary = await this._checkReadItineraryPermission(
       itineraryId,
       user
     )
@@ -1048,7 +1047,10 @@ export class ItineraryService {
     data: CreateContingencyPlanDto,
     user: User
   ) {
-    const itinerary = await this._checkItineraryExists(itineraryId, user)
+    const itinerary = await this._checkUpdateItineraryPermission(
+      itineraryId,
+      user
+    )
     const contingencyCount = await this._checkContingencyCount(itinerary.id)
     const CONTINGENCY_TITLE = ['B', 'C']
     return this.prisma.$transaction(async (prisma) => {


### PR DESCRIPTION
### Changes:
- Streamlined itinerary permission check functions
  - `_checkItineraryExists()` now only checks if itinerary exists or not
  - `_checkReadItineraryPermission()` checks itinerary's read access for user
  - `_checkUpdateItineraryPermission()` checks itinerary's edit access for user
- Changed itinerary permission check used by existing methods in ItineraryService
  - `findOne`: exists -> **READ**
  - `updateItinerary`: remove exists check (redundant)
  - `createContingencyPlan`: exists -> **UPDATE**
  - `findContingencyPlan`: update -> **READ**
  - `findContingencyPlans`: update -> **READ**
- Updated tests for affected existing methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of itinerary permissions, ensuring clearer distinction between read and update access.
- **Bug Fixes**
  - Removed unnecessary debugging output when viewing itinerary details.
- **Tests**
  - Enhanced test coverage to better simulate user access permissions for itineraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->