### PR TITLE
PBI 31 Save Other's Itinerary

### DIFF
--- a/src/itinerary/itinerary.controller.spec.ts
+++ b/src/itinerary/itinerary.controller.spec.ts
@@ -60,6 +60,7 @@ describe('ItineraryController', () => {
     createViewItinerary: jest.fn(),
     getViewItinerary: jest.fn(),
     publishItinerary: jest.fn(),
+    saveItinerary: jest.fn(),
   }
 
   const mockResponseUtil = {
@@ -2520,6 +2521,58 @@ describe('ItineraryController', () => {
       await expect(
         controller.publishItinerary(mockItinerary.id, mockUser, false)
       ).rejects.toThrow(BadRequestException)
+    })
+  })
+
+  describe('saveItinerary', () => {
+    it('should save a public itinerary for the user and return success response', async () => {
+      const itineraryId = 'itn-123'
+      const expectedLikeResult = {
+        id: 'itnlike-1',
+        itineraryId: 'itn-123',
+        userId: mockUser.id,
+      }
+
+      const mockResponse = {
+        statusCode: HttpStatus.CREATED,
+        message: 'Itinerary saved successfully',
+        itinerary: expectedLikeResult,
+      }
+
+      mockItineraryService.saveItinerary.mockResolvedValue(expectedLikeResult)
+      mockResponseUtil.response.mockReturnValue(mockResponse)
+
+      const result = await controller.saveItinerary(itineraryId, mockUser)
+
+      expect(mockItineraryService.saveItinerary).toHaveBeenCalledWith(
+        itineraryId,
+        mockUser
+      )
+
+      expect(mockResponseUtil.response).toHaveBeenCalledWith(
+        {
+          statusCode: HttpStatus.CREATED,
+          message: 'Itinerary saved successfully',
+        },
+        expectedLikeResult
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should pass errors from service to the caller', async () => {
+      const itineraryId = 'itn-123'
+      const mockError = new Error("Cannot save user's own itinerary")
+      mockItineraryService.saveItinerary.mockRejectedValue(mockError)
+      await expect(
+        controller.saveItinerary(itineraryId, mockUser)
+      ).rejects.toThrow(mockError)
+
+      expect(mockItineraryService.saveItinerary).toHaveBeenCalledWith(
+        itineraryId,
+        mockUser
+      )
+
+      expect(mockResponseUtil.response).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/itinerary/itinerary.controller.spec.ts
+++ b/src/itinerary/itinerary.controller.spec.ts
@@ -61,6 +61,7 @@ describe('ItineraryController', () => {
     getViewItinerary: jest.fn(),
     publishItinerary: jest.fn(),
     saveItinerary: jest.fn(),
+    unsaveItinerary: jest.fn(),
   }
 
   const mockResponseUtil = {
@@ -2568,6 +2569,48 @@ describe('ItineraryController', () => {
       ).rejects.toThrow(mockError)
 
       expect(mockItineraryService.saveItinerary).toHaveBeenCalledWith(
+        itineraryId,
+        mockUser
+      )
+
+      expect(mockResponseUtil.response).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unsaveItinerary', () => {
+    it('should unsave the itinerary for the user', async () => {
+      const itineraryId = 'itn-123'
+
+      const mockResponse = {
+        statusCode: HttpStatus.OK,
+        message: 'Itinerary unsaved successfully',
+      }
+
+      mockResponseUtil.response.mockReturnValue(mockResponse)
+
+      const result = await controller.unsaveItinerary(itineraryId, mockUser)
+
+      expect(mockItineraryService.unsaveItinerary).toHaveBeenCalledWith(
+        itineraryId,
+        mockUser
+      )
+
+      expect(mockResponseUtil.response).toHaveBeenCalledWith({
+        statusCode: HttpStatus.OK,
+        message: 'Itinerary unsaved successfully',
+      })
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should pass errors from service to the caller', async () => {
+      const itineraryId = 'itn-123'
+      const mockError = new Error("Cannot unsave user's own itinerary")
+      mockItineraryService.unsaveItinerary.mockRejectedValue(mockError)
+      await expect(
+        controller.unsaveItinerary(itineraryId, mockUser)
+      ).rejects.toThrow(mockError)
+
+      expect(mockItineraryService.unsaveItinerary).toHaveBeenCalledWith(
         itineraryId,
         mockUser
       )

--- a/src/itinerary/itinerary.controller.spec.ts
+++ b/src/itinerary/itinerary.controller.spec.ts
@@ -60,6 +60,8 @@ describe('ItineraryController', () => {
     getViewItinerary: jest.fn(),
     publishItinerary: jest.fn(),
     findTrendingItineraries: jest.fn(),
+    saveItinerary: jest.fn(),
+    unsaveItinerary: jest.fn(),
   }
 
   const mockResponseUtil = {
@@ -2631,7 +2633,7 @@ describe('ItineraryController', () => {
       expect(mockResponseUtil.response).not.toHaveBeenCalled()
     })
   })
-  
+
   describe('saveItinerary', () => {
     it('should save a public itinerary for the user and return success response', async () => {
       const itineraryId = 'itn-123'

--- a/src/itinerary/itinerary.controller.ts
+++ b/src/itinerary/itinerary.controller.ts
@@ -499,4 +499,17 @@ export class ItineraryController {
       publishedItinerary
     )
   }
+
+  @Post(':itineraryId/save')
+  async saveItinerary(@Param('itineraryId') id: string, @GetUser() user: User) {
+    const itineraryLike = await this.itineraryService.saveItinerary(id, user)
+
+    return this.responseUtil.response(
+      {
+        statusCode: HttpStatus.CREATED,
+        message: 'Itinerary saved successfully',
+      },
+      itineraryLike
+    )
+  }
 }

--- a/src/itinerary/itinerary.controller.ts
+++ b/src/itinerary/itinerary.controller.ts
@@ -512,4 +512,17 @@ export class ItineraryController {
       itineraryLike
     )
   }
+
+  @Delete(':itineraryId/save')
+  async unsaveItinerary(
+    @Param('itineraryId') id: string,
+    @GetUser() user: User
+  ) {
+    await this.itineraryService.unsaveItinerary(id, user)
+
+    return this.responseUtil.response({
+      statusCode: HttpStatus.OK,
+      message: 'Itinerary unsaved successfully',
+    })
+  }
 }

--- a/src/itinerary/itinerary.service.spec.ts
+++ b/src/itinerary/itinerary.service.spec.ts
@@ -63,6 +63,11 @@ describe('ItineraryService', () => {
       delete: jest.fn(),
       update: jest.fn(),
     },
+    itineraryLike: {
+      create: jest.fn(),
+      delete: jest.fn(),
+      findUnique: jest.fn(),
+    },
     _checkItineraryExists: jest.fn(),
     _checkContingencyCount: jest.fn(),
   }
@@ -4444,6 +4449,95 @@ describe('ItineraryService', () => {
           viewedAt: expect.any(Date),
         },
       })
+    })
+  })
+
+  describe('saveItinerary', () => {
+    it('should save a public itinerary for the user', async () => {
+      const itineraryId = 'itn-123'
+      const mockItinerary = {
+        id: 'itn-123',
+        userId: 'some other user',
+        isPublished: true,
+      }
+
+      const expectedLikeResult = {
+        id: 'itnlike-1',
+        itineraryId: 'itn-123',
+        userId: mockUser.id,
+      }
+
+      mockPrismaService.itinerary.findUnique.mockResolvedValue(mockItinerary)
+      mockPrismaService.itineraryLike.findUnique.mockResolvedValue(null)
+      mockPrismaService.itineraryLike.create.mockResolvedValue(
+        expectedLikeResult
+      )
+
+      const result = await service.saveItinerary(itineraryId, mockUser)
+
+      expect(mockPrismaService.itineraryLike.create).toHaveBeenCalledWith({
+        data: {
+          itineraryId: itineraryId,
+          userId: mockUser.id,
+        },
+      })
+      expect(result).toEqual(expectedLikeResult)
+    })
+
+    it('should throw NotFoundException if itinerary does not exist', async () => {
+      const itineraryId = 'itn-123'
+      mockPrismaService.itinerary.findUnique.mockResolvedValue(null)
+
+      await expect(
+        service.saveItinerary(itineraryId, mockUser)
+      ).rejects.toThrow(NotFoundException)
+    })
+
+    it('should throw ForbiddenException if user doesnt have access to itinerary', async () => {
+      const itineraryId = 'itn-123'
+      const mockItinerary = {
+        id: 'itn-123',
+        userId: 'some other user',
+        isPublished: false,
+        access: [],
+      }
+      mockPrismaService.itinerary.findUnique.mockResolvedValue(mockItinerary)
+
+      await expect(
+        service.saveItinerary(itineraryId, mockUser)
+      ).rejects.toThrow(ForbiddenException)
+    })
+
+    it('should throw BadRequestException if user owns the itinerary its trying to save', async () => {
+      const itineraryId = 'itn-123'
+      const mockItinerary = {
+        id: 'itn-123',
+        userId: mockUser.id,
+      }
+
+      mockPrismaService.itinerary.findUnique.mockResolvedValue(mockItinerary)
+      mockPrismaService.itineraryLike.findUnique.mockResolvedValue(null)
+
+      await expect(
+        service.saveItinerary(itineraryId, mockUser)
+      ).rejects.toThrow(BadRequestException)
+    })
+
+    it('should throw BadRequestException if user already saved the itinerary', async () => {
+      const itineraryId = 'itn-123'
+      const mockItinerary = {
+        id: 'itn-123',
+        userId: 'some other user',
+        isPublished: true,
+        access: [],
+      }
+
+      mockPrismaService.itinerary.findUnique.mockResolvedValue(mockItinerary)
+      mockPrismaService.itineraryLike.findUnique.mockResolvedValue('something')
+
+      await expect(
+        service.saveItinerary(itineraryId, mockUser)
+      ).rejects.toThrow(BadRequestException)
     })
   })
 })

--- a/src/itinerary/itinerary.service.spec.ts
+++ b/src/itinerary/itinerary.service.spec.ts
@@ -4630,6 +4630,9 @@ describe('ItineraryService', () => {
 
       const result = await service.saveItinerary(itineraryId, mockUser)
 
+      expect(mockMeilisearchService.addOrUpdateItinerary).toHaveBeenCalledWith(
+        mockItinerary
+      )
       expect(mockPrismaService.itineraryLike.create).toHaveBeenCalledWith({
         data: {
           itineraryId: itineraryId,
@@ -4716,6 +4719,9 @@ describe('ItineraryService', () => {
 
       await service.unsaveItinerary(itineraryId, mockUser)
 
+      expect(mockMeilisearchService.addOrUpdateItinerary).toHaveBeenCalledWith(
+        mockItinerary
+      )
       expect(mockPrismaService.itineraryLike.delete).toHaveBeenCalledWith({
         where: { itineraryId_userId: { itineraryId, userId: mockUser.id } },
       })

--- a/src/itinerary/itinerary.service.spec.ts
+++ b/src/itinerary/itinerary.service.spec.ts
@@ -63,6 +63,11 @@ describe('ItineraryService', () => {
       delete: jest.fn(),
       update: jest.fn(),
     },
+    itineraryLike: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
     _checkItineraryExists: jest.fn(),
     _checkContingencyCount: jest.fn(),
   }
@@ -4601,7 +4606,7 @@ describe('ItineraryService', () => {
       expect(result[0].likesCount).toBe(0)
     })
   })
-  
+
   describe('saveItinerary', () => {
     it('should save a public itinerary for the user', async () => {
       const itineraryId = 'itn-123'

--- a/src/itinerary/itinerary.service.ts
+++ b/src/itinerary/itinerary.service.ts
@@ -1542,7 +1542,6 @@ export class ItineraryService {
     return { updatedItinerary }
   }
 
-
   async saveItinerary(itineraryId: string, user: User) {
     const itinerary = await this._checkReadItineraryPermission(
       itineraryId,

--- a/src/itinerary/itinerary.service.ts
+++ b/src/itinerary/itinerary.service.ts
@@ -1566,6 +1566,7 @@ export class ItineraryService {
       },
     })
 
+    this._updateLikeCount(itineraryId)
     return itineraryLike
   }
 
@@ -1587,7 +1588,19 @@ export class ItineraryService {
       where: { itineraryId_userId: { itineraryId, userId: user.id } },
     })
 
+    this._updateLikeCount(itineraryId)
     return itineraryLike
+  }
+
+  async _updateLikeCount(itineraryId: string) {
+    const updatedItinerary = await this.prisma.itinerary.findUnique({
+      where: { id: itineraryId },
+      include: {
+        likes: true,
+      },
+    })
+
+    await this.meilisearchService.addOrUpdateItinerary(updatedItinerary)
   }
 
   async _checkUserSavedItinerary(itineraryId: string, user: User) {

--- a/src/itinerary/itinerary.service.ts
+++ b/src/itinerary/itinerary.service.ts
@@ -1541,10 +1541,9 @@ export class ItineraryService {
 
     const isItinerarySaved = await this._checkUserSavedItinerary(
       itineraryId,
-      user,
-      false
+      user
     )
-    if (!isItinerarySaved) {
+    if (isItinerarySaved) {
       throw new BadRequestException('Itinerary already saved by user')
     }
 
@@ -1564,12 +1563,11 @@ export class ItineraryService {
       throw new BadRequestException("Cannot unsave user's own itinerary")
     }
 
-    const isItineraryNotSaved = await this._checkUserSavedItinerary(
+    const isItinerarySaved = await this._checkUserSavedItinerary(
       itineraryId,
-      user,
-      true
+      user
     )
-    if (!isItineraryNotSaved) {
+    if (!isItinerarySaved) {
       throw new BadRequestException('Itinerary is not saved by user')
     }
 
@@ -1580,21 +1578,11 @@ export class ItineraryService {
     return itineraryLike
   }
 
-  async _checkUserSavedItinerary(
-    itineraryId: string,
-    user: User,
-    expectExists: boolean
-  ) {
+  async _checkUserSavedItinerary(itineraryId: string, user: User) {
     const itineraryLike = await this.prisma.itineraryLike.findUnique({
       where: { itineraryId_userId: { itineraryId, userId: user.id } },
     })
 
-    if (!itineraryLike && expectExists) {
-      return false
-    }
-    if (itineraryLike && !expectExists) {
-      return false
-    }
-    return true
+    return itineraryLike !== null
   }
 }


### PR DESCRIPTION
### Changes:
- Added implementation for saving another user's itinerary to a User
  - `saveItinerary`: saves itinerary for User
  - `unsaveItinerary`: unsaves itinerary (remove from saved) for User
- Added supporting endpoints for /itinerary/
  - `POST /id/save`: save itinerary
  - `DELETE /id/save`: unsave itinerary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to save public itineraries to their account.
  - Added the ability for users to remove (unsave) previously saved itineraries.

- **Bug Fixes**
  - Improved error handling for saving and unsaving itineraries, including checks to prevent users from saving their own itineraries or performing invalid actions.

- **Tests**
  - Added comprehensive tests for saving and unsaving itineraries, covering both successful operations and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->