### PR TITLE
Improve PBI 31 Save Other's Itinerary 

### DIFF
--- a/src/itinerary/itinerary.controller.spec.ts
+++ b/src/itinerary/itinerary.controller.spec.ts
@@ -64,6 +64,7 @@ describe('ItineraryController', () => {
     findTrendingItineraries: jest.fn(),
     saveItinerary: jest.fn(),
     unsaveItinerary: jest.fn(),
+    batchCheckUserSavedItinerary: jest.fn(),
   }
 
   const mockResponseUtil = {
@@ -3117,6 +3118,46 @@ describe('ItineraryController', () => {
       )
 
       expect(mockResponseUtil.response).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('batchCheckUserSavedItinerary', () => {
+    it('should check saved status of public itinerary ids for the user and return success response', async () => {
+      const itineraryIds = ['itn-123', 'itn-456', 'itn-789']
+      const expectedBatchSaveCheckResult = {
+        'itn-123': true,
+        'itn-456': false,
+        'itn-789': false,
+      }
+
+      const mockResponse = {
+        statusCode: HttpStatus.OK,
+        message: 'Itineraries saved status fetched succesfully',
+        itinerary: expectedBatchSaveCheckResult,
+      }
+
+      mockItineraryService.batchCheckUserSavedItinerary.mockResolvedValue(
+        expectedBatchSaveCheckResult
+      )
+      mockResponseUtil.response.mockReturnValue(mockResponse)
+
+      const result = await controller.batchCheckUserSavedItinerary(
+        mockUser,
+        itineraryIds
+      )
+
+      expect(
+        mockItineraryService.batchCheckUserSavedItinerary
+      ).toHaveBeenCalledWith(itineraryIds, mockUser)
+
+      expect(mockResponseUtil.response).toHaveBeenCalledWith(
+        {
+          statusCode: HttpStatus.OK,
+          message: 'Itineraries saved status fetched succesfully',
+        },
+        expectedBatchSaveCheckResult
+      )
+      expect(result).toEqual(mockResponse)
     })
   })
 })

--- a/src/itinerary/itinerary.controller.ts
+++ b/src/itinerary/itinerary.controller.ts
@@ -549,7 +549,7 @@ export class ItineraryController {
       }
     )
   }
-  
+
   @Post(':itineraryId/save')
   async saveItinerary(@Param('itineraryId') id: string, @GetUser() user: User) {
     const itineraryLike = await this.itineraryService.saveItinerary(id, user)
@@ -574,5 +574,24 @@ export class ItineraryController {
       statusCode: HttpStatus.OK,
       message: 'Itinerary unsaved successfully',
     })
+  }
+
+  @Get('/checkSave')
+  async batchCheckUserSavedItinerary(
+    @GetUser() user: User,
+    @Body() itineraryIds: string[]
+  ) {
+    const result = await this.itineraryService.batchCheckUserSavedItinerary(
+      itineraryIds,
+      user
+    )
+
+    return this.responseUtil.response(
+      {
+        statusCode: HttpStatus.OK,
+        message: 'Itineraries saved status fetched succesfully',
+      },
+      result
+    )
   }
 }

--- a/src/itinerary/itinerary.service.ts
+++ b/src/itinerary/itinerary.service.ts
@@ -1698,6 +1698,18 @@ export class ItineraryService {
     await this.meilisearchService.addOrUpdateItinerary(updatedItinerary)
   }
 
+  async batchCheckUserSavedItinerary(itineraryIds: string[], user: User) {
+    let result: { [key: string]: boolean } = {}
+    const itineraryLikes = await this.prisma.itineraryLike.findMany({
+      where: { itineraryId: { in: itineraryIds }, userId: user.id },
+    })
+    const likedItineraryIds = itineraryLikes.map((like) => like.itineraryId)
+    for (const itineraryId of itineraryIds) {
+      result[itineraryId] = likedItineraryIds.includes(itineraryId)
+    }
+    return result
+  }
+
   async _checkUserSavedItinerary(itineraryId: string, user: User) {
     const itineraryLike = await this.prisma.itineraryLike.findUnique({
       where: { itineraryId_userId: { itineraryId, userId: user.id } },


### PR DESCRIPTION
### Changes:
- Added implementation for batch checking the User saved status for a list of itinerary ids
   - `batchCheckUserSavedItinerary`: checks the User saved status for a list of itinerary ids
 - Added supporting endpoints for /itinerary/
   - `GET /checkSave`: checks the saved status for a list of itinerary ids
