### PR TITLE
Fix Recent Viewed Itineraries include tags object

### DIFF
--- a/src/itinerary/itinerary.service.spec.ts
+++ b/src/itinerary/itinerary.service.spec.ts
@@ -4496,7 +4496,11 @@ describe('ItineraryService', () => {
                     likes: true,
                   }),
                 }),
-                tags: true,
+                tags: expect.objectContaining({
+                  select: expect.objectContaining({
+                    tag: true,
+                  }),
+                }),
               }),
             }),
           }),

--- a/src/itinerary/itinerary.service.ts
+++ b/src/itinerary/itinerary.service.ts
@@ -1632,7 +1632,11 @@ export class ItineraryService {
               },
             },
             // Make sure to include tags if needed
-            tags: true,
+            tags: {
+              select: {
+                tag: true,
+              },
+            },
           },
         },
       },
@@ -1662,6 +1666,8 @@ export class ItineraryService {
         likes: itinerary._count.likes ?? 0,
       }
     })
+
+    console.log('format views', formattedViews)
 
     return formattedViews
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the structure of tag data returned when viewing itineraries, ensuring only relevant tag information is included.

- **Chores**
  - Enhanced test coverage to reflect the updated tag data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->