### PR TITLE
Fix and enhance tour search with improved duration filtering

### DIFF
--- a/src/tour/tour.controller.spec.ts
+++ b/src/tour/tour.controller.spec.ts
@@ -3,14 +3,11 @@ import { TourController } from './tour.controller'
 import { TourService } from './tour.service'
 import { ResponseUtil } from 'src/common/utils/response.util'
 import { HttpStatus } from '@nestjs/common'
-import { DURATION_TYPE } from '@prisma/client'
-import { PrismaService } from 'src/prisma/prisma.service'
 
 describe('TourController', () => {
   let controller: TourController
   let tourService: TourService
   let responseUtil: ResponseUtil
-
 
   const mockResponseUtil = {
     response: jest.fn(),
@@ -237,9 +234,9 @@ describe('TourController', () => {
   describe('findOne', () => {
     it('should return a successful response with tour data', async () => {
       const mockTourData = {
-      id: 'tour123',
-      title: 'Test tour',
-    }
+        id: 'tour123',
+        title: 'Test tour',
+      }
 
       const mockResponse = {
         statusCode: HttpStatus.OK,

--- a/src/tour/tour.controller.ts
+++ b/src/tour/tour.controller.ts
@@ -22,50 +22,6 @@ export class TourController {
   ) {}
 
   @Public()
-  @Get(':id')
-  async findOne(@Param('id') id: string) {
-    const tour = await this.tourService.findOne(id)
-
-    return this.responseUtil.response(
-      {
-        statusCode: HttpStatus.OK,
-        message: 'Tour fetched successfully.',
-      },
-      {
-        data: tour,
-      }
-    )
-  }
-
-  @Post('views/:tourId')
-  async createTourView(@GetUser() user: User, @Param('tourId') tourId: string) {
-    const tour = await this.tourService.createTourView(tourId, user)
-    return this.responseUtil.response(
-      {
-        statusCode: HttpStatus.CREATED,
-        message: 'Tour view added successfully',
-      },
-      {
-        tour,
-      }
-    )
-  }
-
-  @Get('views')
-  async getTourView(@GetUser() user: User) {
-    const tours = await this.tourService.getTourView(user)
-    return this.responseUtil.response(
-      {
-        statusCode: HttpStatus.OK,
-        message: 'Tour views fetched successfully',
-      },
-      {
-        tours,
-      }
-    )
-  }
-
-  @Public()
   @Get('search')
   async searchTours(
     @Query('q') query: string = '',
@@ -132,5 +88,49 @@ export class TourController {
     return {
       suggestions: suggestions.slice(0, 5),
     }
+  }
+
+  @Public()
+  @Get(':id')
+  async findOne(@Param('id') id: string) {
+    const tour = await this.tourService.findOne(id)
+
+    return this.responseUtil.response(
+      {
+        statusCode: HttpStatus.OK,
+        message: 'Tour fetched successfully.',
+      },
+      {
+        data: tour,
+      }
+    )
+  }
+
+  @Post('views/:tourId')
+  async createTourView(@GetUser() user: User, @Param('tourId') tourId: string) {
+    const tour = await this.tourService.createTourView(tourId, user)
+    return this.responseUtil.response(
+      {
+        statusCode: HttpStatus.CREATED,
+        message: 'Tour view added successfully',
+      },
+      {
+        tour,
+      }
+    )
+  }
+
+  @Get('views')
+  async getTourView(@GetUser() user: User) {
+    const tours = await this.tourService.getTourView(user)
+    return this.responseUtil.response(
+      {
+        statusCode: HttpStatus.OK,
+        message: 'Tour views fetched successfully',
+      },
+      {
+        tours,
+      }
+    )
   }
 }

--- a/src/tour/tour.service.spec.ts
+++ b/src/tour/tour.service.spec.ts
@@ -43,8 +43,8 @@ describe('TourService', () => {
       delete: jest.fn(),
     },
     tourIncludes: {
-      findMany: jest.fn()
-    }
+      findMany: jest.fn(),
+    },
   }
 
   const mockMeilisearchService = {

--- a/src/tour/tour.service.spec.ts
+++ b/src/tour/tour.service.spec.ts
@@ -321,18 +321,17 @@ describe('TourService', () => {
         'asc'
       )
 
+      // Updated to match the new filter format
       expect(mockMeilisearchService.searchTours).toHaveBeenCalledWith('paris', {
         limit: 10,
         offset: 10,
         filter: [
-          [
-            'location = "Paris, France"',
-            'pricePerTicket >= 50',
-            'pricePerTicket <= 150',
-            'duration >= 4',
-            'durationType = "HOUR"',
-            'availableTickets > 0',
-          ],
+          'location = "Paris, France"',
+          'pricePerTicket >= 50',
+          'pricePerTicket <= 150',
+          'durationType = "HOUR"',
+          'duration >= 4',
+          'availableTickets > 0',
         ],
         sort: ['pricePerTicket:asc'],
       })
@@ -359,28 +358,49 @@ describe('TourService', () => {
     it('should handle various duration filters correctly', async () => {
       // Test with only minDuration
       await service.searchTours('', 1, 10, { minDuration: 2 })
+
+      // Updated to match the correct capitalization of duration types (DAY and HOUR)
       expect(mockMeilisearchService.searchTours).toHaveBeenLastCalledWith(
         '',
         expect.objectContaining({
-          filter: [['duration >= 2']],
+          filter: [
+            [
+              ['duration >= 2', 'durationType = "DAY"'],
+              ['duration >= 2', 'durationType = "HOUR"'],
+            ],
+          ],
         })
       )
 
       // Test with only maxDuration
       await service.searchTours('', 1, 10, { maxDuration: 5 })
+
+      // Updated with correct capitalization
       expect(mockMeilisearchService.searchTours).toHaveBeenLastCalledWith(
         '',
         expect.objectContaining({
-          filter: [['duration <= 5']],
+          filter: [
+            [
+              ['duration <= 5', 'durationType = "DAY"'],
+              ['duration <= 5', 'durationType = "HOUR"'],
+            ],
+          ],
         })
       )
 
       // Test with both min and max duration
       await service.searchTours('', 1, 10, { minDuration: 2, maxDuration: 5 })
+
+      // Updated with correct capitalization
       expect(mockMeilisearchService.searchTours).toHaveBeenLastCalledWith(
         '',
         expect.objectContaining({
-          filter: [['duration >= 2', 'duration <= 5']],
+          filter: [
+            [
+              ['duration >= 2', 'duration <= 5', 'durationType = "DAY"'],
+              ['duration >= 2', 'duration <= 5', 'durationType = "HOUR"'],
+            ],
+          ],
         })
       )
     })
@@ -388,10 +408,12 @@ describe('TourService', () => {
     // Additional test for single filter
     it('should handle a single filter correctly', async () => {
       await service.searchTours('', 1, 10, { location: 'Tokyo, Japan' })
+
+      // Updated to match the new filter format for single filter
       expect(mockMeilisearchService.searchTours).toHaveBeenLastCalledWith(
         '',
         expect.objectContaining({
-          filter: [['location = "Tokyo, Japan"']],
+          filter: ['location = "Tokyo, Japan"'],
         })
       )
     })
@@ -403,6 +425,22 @@ describe('TourService', () => {
         '',
         expect.objectContaining({
           filter: undefined,
+        })
+      )
+    })
+
+    // New test for duration with durationType specified
+    it('should handle duration with durationType correctly', async () => {
+      await service.searchTours('', 1, 10, {
+        minDuration: 2,
+        maxDuration: 5,
+        durationType: 'DAY',
+      })
+
+      expect(mockMeilisearchService.searchTours).toHaveBeenLastCalledWith(
+        '',
+        expect.objectContaining({
+          filter: ['durationType = "DAY"', 'duration >= 2', 'duration <= 5'],
         })
       )
     })


### PR DESCRIPTION
This PR addresses issues with the tour search functionality, particularly focusing on fixing the duration filtering mechanism. The current implementation didn't correctly handle scenarios where both duration values (min/max) and durationType were used together in search filters. This also fixed where the `/tour/search` and `/tour/suggestions` endpoint doesn't recognized as its own endpoint because it is overridden by get `/tour/:id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved duration filtering for tour searches to ensure accurate results when specifying duration type, minimum, and maximum durations.
	- Corrected filter formats and capitalization in search-related tests for consistency and reliability.

- **Refactor**
	- Reorganized the order of certain controller methods without changing their behavior.

- **Style**
	- Made minor formatting improvements in test files for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->