### PR TITLE
fix: Check DOKU_ENV variabel instead of NODE_ENV

### DIFF
--- a/src/doku/doku.service.spec.ts
+++ b/src/doku/doku.service.spec.ts
@@ -10,7 +10,7 @@ describe('DokuService', () => {
   const mockedUuid = 'fccaee9c-d613-40cc-a1e4-12a596fad604'
 
   const mockConfigValues = {
-    NODE_ENV: 'development',
+    DOKU_ENV: 'development',
     DOKU_CLIENT_ID: 'test-client-id',
     DOKU_CLIENT_SECRET: 'test-secret-key',
   }
@@ -59,7 +59,7 @@ describe('DokuService', () => {
 
     it('should set baseUrl to production in production environment', async () => {
       jest.spyOn(configService, 'get').mockImplementation((key: string) => {
-        if (key === 'NODE_ENV') return 'production'
+        if (key === 'DOKU_ENV') return 'production'
         return mockConfigValues[key]
       })
 

--- a/src/doku/doku.service.ts
+++ b/src/doku/doku.service.ts
@@ -10,7 +10,7 @@ export class DokuService {
 
   constructor(private readonly configService: ConfigService) {
     this.baseUrl =
-      this.configService.get<string>('NODE_ENV') === 'production'
+      this.configService.get<string>('DOKU_ENV') === 'production'
         ? 'https://api.doku.com'
         : 'https://api-sandbox.doku.com'
     this.clientId = this.configService.get<string>('DOKU_CLIENT_ID')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated environment variable from `NODE_ENV` to `DOKU_ENV` for determining the API endpoint. This change does not affect user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->